### PR TITLE
Fix/fix ags broken icons

### DIFF
--- a/home-manager/cli/default.nix
+++ b/home-manager/cli/default.nix
@@ -15,6 +15,7 @@
       less
       wget
       lazygit
+      btop
 
       # data
       minio-client

--- a/nixos/features/desktop/default.nix
+++ b/nixos/features/desktop/default.nix
@@ -37,7 +37,7 @@
     gnome-calendar
     gnome-system-monitor
     gnome-calculator
-
+    gnome-tweaks
     # Wayland /  Hyprland
     mako
     libnotify


### PR DESCRIPTION
not sure how it got fixed. opened gnome-tweaks once and clicked arond and that seem to have solved the broken icon links. Correct packages were instealled already.